### PR TITLE
Allow symbol key values for liquid variables

### DIFF
--- a/test/test_card.rb
+++ b/test/test_card.rb
@@ -5,7 +5,7 @@ class TestCard < MinitestShopify::LiquidTest
   MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
 
   def test_renders_a_card
-    render template: "snippets/card", variables: { "comment" => default_comment }
+    render template: "snippets/card", variables: { comment: default_comment }
     assert_text "Hello world!"
     assert_text "John Doe"
   end
@@ -14,12 +14,12 @@ class TestCard < MinitestShopify::LiquidTest
 
   def default_comment
     {
-      "id" => 1,
-      "created_at" => "2023-07-20T19:31:35Z",
-      "content" => "Hello world!",
-      "author" => {
-        "id" => 1,
-        "name" => "John Doe"
+      id: 1,
+      created_at: "2023-07-20T19:31:35Z",
+      content: "Hello world!",
+      author: {
+        id: 1,
+        name: "John Doe"
       }
     }
   end

--- a/test/test_card_view.rb
+++ b/test/test_card_view.rb
@@ -5,7 +5,7 @@ class TestCardView < MinitestShopify::ViewTest
   MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
 
   def test_javascript_enabled_card
-    render template: "snippets/js-card", variables: { "comment" => default_comment }
+    render template: "snippets/js-card", variables: { comment: default_comment }
 
     within "#comment-1" do
       assert_text "Javascript is enabled"
@@ -17,8 +17,8 @@ class TestCardView < MinitestShopify::ViewTest
 
   def default_comment
     {
-      "id" => 1,
-      "content" => "Hello world!",
+      id: 1,
+      content: "Hello world!",
     }
   end
 end

--- a/test/test_layout.rb
+++ b/test/test_layout.rb
@@ -6,7 +6,7 @@ class TestLayout < MinitestShopify::LiquidTest
   MinitestShopify.configuration.layout_file = File.join("layout/theme")
 
   def test_renders_snippet_with_layout
-    render template: "snippets/card", variables: { "comment" => default_comment }
+    render template: "snippets/card", variables: { comment: default_comment }
     assert_text "Hello layout!"
     assert_selector "body.custom-layout"
     assert_selector "section"
@@ -16,8 +16,8 @@ class TestLayout < MinitestShopify::LiquidTest
 
   def default_comment
     {
-      "id" => 1,
-      "content" => "Hello layout!",
+      id: 1,
+      content: "Hello layout!",
     }
   end
 end

--- a/test/test_section.rb
+++ b/test/test_section.rb
@@ -6,12 +6,12 @@ class TestSection < MinitestShopify::LiquidTest
     MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
 
     section_settings = {
-      "settings" => {
-        "title" => "Hello world!",
-        "text" => "A long paragraph of text goes here. It should be long enough to wrap to the next line.",
+      settings: {
+        title: "Hello world!",
+        text: "A long paragraph of text goes here. It should be long enough to wrap to the next line.",
       }
     }
-    render template: "sections/text", variables: { "section" => section_settings }
+    render template: "sections/text", variables: { section: section_settings }
     assert_selector "h2", text: "Hello world!"
     assert_selector "p", text: "A long paragraph of text goes here. It should be long enough to wrap to the next line."
   end
@@ -20,12 +20,12 @@ class TestSection < MinitestShopify::LiquidTest
     MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
 
     section_settings = {
-      "settings" => {
-        "title" => "Hello world!",
-        "image" => "files/image.jpg"
+      settings: {
+        title: "Hello world!",
+        image: "files/image.jpg"
       }
     }
-    render template: "sections/image-with-title", variables: { "section" => section_settings }
+    render template: "sections/image-with-title", variables: { section: section_settings }
     assert_selector "h2", text: "Hello world!"
     assert_element "img", "src": "files/image.jpg"
   end


### PR DESCRIPTION
Allows the use of either `{ "foo" => "bar"}` or the standard Rails `{ foo: "bar" }` when defining variables for the liquid template!