### PR TITLE
Stricter checks and `text`/`html` helpers

### DIFF
--- a/lib/minitest_shopify/configuration.rb
+++ b/lib/minitest_shopify/configuration.rb
@@ -1,4 +1,5 @@
 require "pathname"
+require "liquid"
 
 class MinitestShopify::Configuration
   attr_reader :theme_root

--- a/lib/minitest_shopify/liquid_test.rb
+++ b/lib/minitest_shopify/liquid_test.rb
@@ -30,7 +30,7 @@ class MinitestShopify::LiquidTest < Minitest::Test
   def render_liquid(template:, variables:)
     file = File.read(File.join(MinitestShopify.configuration.theme_root, template) + ".liquid")
     template = Liquid::Template.parse(file, error_mode: :strict)
-    template.render!(deep_stringify_keys(variables))
+    @output = template.render!(deep_stringify_keys(variables), {strict_variables: true, strict_filters: true})
   end
 
   def deep_stringify_keys(hash)

--- a/minitest_shopify.gemspec
+++ b/minitest_shopify.gemspec
@@ -43,4 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('zeitwerk')
   spec.add_dependency('i18n')
   spec.add_dependency('money')
+  spec.add_dependency('loofah')
 end

--- a/test/test_card_view.rb
+++ b/test/test_card_view.rb
@@ -18,7 +18,13 @@ class TestCardView < MinitestShopify::ViewTest
   def default_comment
     {
       id: 1,
+      created_at: "2023-07-20T19:31:35Z",
       content: "Hello world!",
+      author: {
+        id: 1,
+        name: "John Doe"
+      }
     }
+
   end
 end

--- a/test/test_layout.rb
+++ b/test/test_layout.rb
@@ -17,7 +17,13 @@ class TestLayout < MinitestShopify::LiquidTest
   def default_comment
     {
       id: 1,
+      created_at: "2023-07-20T19:31:35Z",
       content: "Hello layout!",
+      author: {
+        id: 1,
+        name: "John Doe"
+      }
     }
+
   end
 end


### PR DESCRIPTION
This pull request includes updates to the `minitest_shopify` library, focusing on enhancing Liquid template rendering, improving test data structures, and introducing stricter rendering options. The most important changes include adding dependencies for `liquid` and `loofah`, modifying Liquid rendering logic for stricter validation, and updating test data to include additional fields.

### Enhancements to Liquid rendering:

* [`lib/minitest_shopify/configuration.rb`](diffhunk://#diff-4a40c3687419d4e11198566e0349f76ab4c2c6e12d032d5fe08da9c71f87d981R2): Added `liquid` as a required dependency for the configuration file.
* [`lib/minitest_shopify/liquid_test.rb`](diffhunk://#diff-ef4beea79f30413844269062ced2da7b292fb48ff41d1a062afb7e0fec1315ccR4): Added `loofah` dependency and modified the `render_liquid` method to enable strict validation for variables and filters. Introduced new methods `text` and `html` for processing rendered Liquid output using `Loofah`. [[1]](diffhunk://#diff-ef4beea79f30413844269062ced2da7b292fb48ff41d1a062afb7e0fec1315ccR4) [[2]](diffhunk://#diff-ef4beea79f30413844269062ced2da7b292fb48ff41d1a062afb7e0fec1315ccL28-R41)
* [`minitest_shopify.gemspec`](diffhunk://#diff-8dd114b85e2d89c07e99dcd0f2796dc1544c2fbe152e08886f561c82164305f8R46): Declared `loofah` as a gem dependency.

### Improvements to test data structures:

* [`test/test_card_view.rb`](diffhunk://#diff-94b546bd8b38c73ab272e16a1b6b8131816c9f8447585eee55fe94223e434e1dR21-R28): Updated the `default_comment` structure to include `created_at` and `author` fields for better test coverage.
* [`test/test_layout.rb`](diffhunk://#diff-8b23a5529f458cbbbc6be563e2f2031903fca8a9b44b4964107993d97a6517c9R20-R27): Added `created_at` and `author` fields to the `default_comment` structure in layout-related tests.

### Code simplification:

* [`lib/minitest_shopify/liquid_test.rb`](diffhunk://#diff-ef4beea79f30413844269062ced2da7b292fb48ff41d1a062afb7e0fec1315ccL15-R17): Refactored conditional logic in the `render` method to simplify readability.