### PR TITLE
Add I18n filters support

### DIFF
--- a/lib/minitest_shopify/filters/translations_filter.rb
+++ b/lib/minitest_shopify/filters/translations_filter.rb
@@ -1,0 +1,46 @@
+require 'i18n'
+
+module MinitestShopify::Filters::TranslationsFilter
+  module TestHelper
+    def setup
+      super
+
+      Dir["#{MinitestShopify.configuration.theme_root}/locales/*.json"].each do |file|
+        next if file.end_with?('.schema.json')
+
+        command = %{node -pe "JSON.stringify(eval('data='+require('fs').readFileSync(0, 'utf8')))"}
+        # Use Node.js to parse JSON, as it handles comments in JSON files
+        # and is more lenient than Ruby's JSON parser.
+        r, w = IO.pipe
+        pid = Process.spawn(command, in: file, out: w, err: :close, close_others: true)
+        w.close
+        Process.wait(pid)
+        raise "Failed to parse JSON from #{file}" unless $?.success?
+        contents = r.read
+        r.close
+        require 'json'
+        data = JSON.parse!(contents) rescue binding.irb
+        locale = File.basename(file, '.json').chomp(".default")
+        I18n.backend.store_translations(locale.to_sym, data)
+        if file.end_with?('.default.json')
+          @default_locale = locale.to_sym
+        end
+      end
+
+      I18n.locale = @default_locale || I18n.default_locale
+    end
+  end
+
+  def t(key, variables = {})
+    I18n.t(key).gsub(/{{\s*([a-zA-Z0-9_]+)\s*}}/) do |match|
+      var_name = $1
+      if variables.key?(var_name)
+        variables[var_name].to_s
+      else
+        match # Return the original match if variable not found
+      end
+    end
+  end
+
+  Liquid::Environment.default.register_filter(self)
+end

--- a/lib/minitest_shopify/liquid_test.rb
+++ b/lib/minitest_shopify/liquid_test.rb
@@ -7,6 +7,7 @@ MinitestShopify.loader.eager_load_namespace(MinitestShopify::Filters)
 
 class MinitestShopify::LiquidTest < Minitest::Test
   include Capybara::Minitest::Assertions
+  include MinitestShopify::Filters::TranslationsFilter::TestHelper
 
   def render(template:, variables: {})
     @page = render_liquid(template:, variables:)

--- a/minitest_shopify.gemspec
+++ b/minitest_shopify.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('liquid')
   spec.add_dependency('bigdecimal')
   spec.add_dependency('zeitwerk')
+  spec.add_dependency('i18n')
 end

--- a/test/theme/locales/en.default.json
+++ b/test/theme/locales/en.default.json
@@ -1,0 +1,3 @@
+{
+  "hello": "Hello"
+}


### PR DESCRIPTION
This pull request introduces functionality to support translations in `MinitestShopify` by integrating the `i18n` gem and adding a mechanism to parse and store locale data from JSON files. The changes include adding translation helpers, updating dependencies, and modifying tests to use the new features.

### Translation Support

* [`lib/minitest_shopify/filters/translations_filter.rb`](diffhunk://#diff-004db7ac30dbf2fbe909fce94cf7012ae8a1c48fab34d7f9ed586f1e477757beR1-R46): Added a `TranslationsFilter` module that parses locale JSON files using Node.js, stores translations in `I18n.backend`, and provides a `t` method for translation with variable substitution.
* [`lib/minitest_shopify/liquid_test.rb`](diffhunk://#diff-ef4beea79f30413844269062ced2da7b292fb48ff41d1a062afb7e0fec1315ccR10): Included the `TranslationsFilter::TestHelper` module to enable translation functionality in tests.

### Dependency Updates

* [`minitest_shopify.gemspec`](diffhunk://#diff-8dd114b85e2d89c07e99dcd0f2796dc1544c2fbe152e08886f561c82164305f8R44): Added a dependency on the `i18n` gem to support translations.

### Test Updates

* [`test/theme/locales/en.default.json`](diffhunk://#diff-508d06ac9e90d22fac06a839b6c94fb09be04d8ef840712831f324f11d07afedR1-R3): Added a sample locale file (`en.default.json`) for testing translation functionality.