### PR TITLE
Add Money filters support

### DIFF
--- a/lib/minitest_shopify/filters/money_filter.rb
+++ b/lib/minitest_shopify/filters/money_filter.rb
@@ -1,0 +1,29 @@
+require 'money'
+
+module MinitestShopify::Filters::MoneyFilter
+  module TestHelper
+    def setup
+      super
+      Money.locale_backend = :i18n
+    end
+  end
+
+  class ShopifyMoney < Money
+    self.rounding_mode = BigDecimal::ROUND_HALF_UP
+    self.locale_backend = :i18n
+
+    def to_liquid
+      to_json
+    end
+
+    def to_liquid_value
+      to_html
+    end
+  end
+
+  def money(input, currency: "USD")
+    ShopifyMoney.new(input, currency)
+  end
+
+  Liquid::Environment.default.register_filter(self)
+end

--- a/lib/minitest_shopify/liquid_test.rb
+++ b/lib/minitest_shopify/liquid_test.rb
@@ -8,6 +8,7 @@ MinitestShopify.loader.eager_load_namespace(MinitestShopify::Filters)
 class MinitestShopify::LiquidTest < Minitest::Test
   include Capybara::Minitest::Assertions
   include MinitestShopify::Filters::TranslationsFilter::TestHelper
+  include MinitestShopify::Filters::MoneyFilter::TestHelper
 
   def render(template:, variables: {})
     @page = render_liquid(template:, variables:)

--- a/minitest_shopify.gemspec
+++ b/minitest_shopify.gemspec
@@ -42,4 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency('bigdecimal')
   spec.add_dependency('zeitwerk')
   spec.add_dependency('i18n')
+  spec.add_dependency('money')
 end


### PR DESCRIPTION
### New Filter for Money:

* [`lib/minitest_shopify/filters/money_filter.rb`](diffhunk://#diff-54694e8b7e48dbbedf5646e95fe1aef1493372661f3b25a1d270f24c604d103cR1-R29): Added a `MoneyFilter` module with helper methods for handling money objects in tests, including `ShopifyMoney` class for rounding and localization, and methods for rendering money as JSON or HTML. The filter is registered with Liquid.
