### PR TITLE
Rename to `minitest_shopify_themes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Prototype of a minitest test class with capybara assertions capable of rendering
 
 ## Example
 ```ruby
-MinitestShopify.configure do |config|
+MinitestShopifyThemes.configure do |config|
   config.theme_root = File.join(__dir__, "theme")
   config.selenium_driver = :selenium_chrome_headless
   config.layout_file = "layout/theme"
@@ -13,9 +13,9 @@ end
 
 ```ruby
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestCard < MinitestShopify::LiquidTest
+class TestCard < MinitestShopifyThemes::LiquidTest
   def test_renders_a_card
     render template: "snippets/card", variables: { comment: default_comment }
     assert_text "Hello world!"
@@ -42,9 +42,9 @@ You can also use selenium to run tests that involve JavaScript or assets:
 
 ```ruby
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestCardView < MinitestShopify::ViewTest
+class TestCardView < MinitestShopifyThemes::ViewTest
   def test_javascript_enabled_card
     render template: "snippets/js-card", variables: { comment: default_comment }
     within "#comment-1" do
@@ -68,5 +68,5 @@ end
 This is an experiment for the time being, if you want to try it out for yourself you can add the following definition to your gemfile:
 
 ```ruby
-gem "minitest_shopify", git: "https://github.com/nebulab/minitest_shopify.git", branch: "main"
+gem "minitest_shopify_themes", git: "https://github.com/nebulab/minitest_shopify_themes.git", branch: "main"
 ```

--- a/lib/minitest_shopify_themes.rb
+++ b/lib/minitest_shopify_themes.rb
@@ -1,7 +1,7 @@
-require_relative "minitest_shopify/version"
+require_relative "minitest_shopify_themes/version"
 require "zeitwerk"
 
-module MinitestShopify
+module MinitestShopifyThemes
   def self.loader
     @loader ||= Zeitwerk::Loader.for_gem
   end

--- a/lib/minitest_shopify_themes/configuration.rb
+++ b/lib/minitest_shopify_themes/configuration.rb
@@ -1,7 +1,7 @@
 require "pathname"
 require "liquid"
 
-class MinitestShopify::Configuration
+class MinitestShopifyThemes::Configuration
   attr_reader :theme_root
   attr_accessor :selenium_driver, :layout_file
 
@@ -19,7 +19,7 @@ class MinitestShopify::Configuration
     # only used to render a snippet or app block, however, we cannot
     # emulate the render of an app block, so its okay to default to
     # snippets.
-    Liquid::Environment.default.file_system = MinitestShopify::LocalFileSystem.new(@theme_root.to_s, "snippets/%s.liquid")
+    Liquid::Environment.default.file_system = MinitestShopifyThemes::LocalFileSystem.new(@theme_root.to_s, "snippets/%s.liquid")
   end
 
   def assets_dir

--- a/lib/minitest_shopify_themes/filters/assets_filter.rb
+++ b/lib/minitest_shopify_themes/filters/assets_filter.rb
@@ -1,4 +1,4 @@
-module MinitestShopify::Filters::AssetsFilter
+module MinitestShopifyThemes::Filters::AssetsFilter
   def asset_url(input)
     File.join("/assets", input)
   end

--- a/lib/minitest_shopify_themes/filters/image_filter.rb
+++ b/lib/minitest_shopify_themes/filters/image_filter.rb
@@ -1,4 +1,4 @@
-module MinitestShopify::Filters::ImageFilter
+module MinitestShopifyThemes::Filters::ImageFilter
   def image_url(input, width = nil, height = nil)
     input
   end

--- a/lib/minitest_shopify_themes/filters/money_filter.rb
+++ b/lib/minitest_shopify_themes/filters/money_filter.rb
@@ -1,6 +1,6 @@
 require 'money'
 
-module MinitestShopify::Filters::MoneyFilter
+module MinitestShopifyThemes::Filters::MoneyFilter
   module TestHelper
     def setup
       super

--- a/lib/minitest_shopify_themes/filters/translations_filter.rb
+++ b/lib/minitest_shopify_themes/filters/translations_filter.rb
@@ -1,11 +1,11 @@
 require 'i18n'
 
-module MinitestShopify::Filters::TranslationsFilter
+module MinitestShopifyThemes::Filters::TranslationsFilter
   module TestHelper
     def setup
       super
 
-      Dir["#{MinitestShopify.configuration.theme_root}/locales/*.json"].each do |file|
+      Dir["#{MinitestShopifyThemes.configuration.theme_root}/locales/*.json"].each do |file|
         next if file.end_with?('.schema.json')
 
         command = %{node -pe "JSON.stringify(eval('data='+require('fs').readFileSync(0, 'utf8')))"}

--- a/lib/minitest_shopify_themes/liquid_test.rb
+++ b/lib/minitest_shopify_themes/liquid_test.rb
@@ -3,20 +3,20 @@ require "capybara/minitest"
 require "liquid"
 require "loofah"
 
-MinitestShopify.loader.eager_load_namespace(MinitestShopify::Tags)
-MinitestShopify.loader.eager_load_namespace(MinitestShopify::Filters)
+MinitestShopifyThemes.loader.eager_load_namespace(MinitestShopifyThemes::Tags)
+MinitestShopifyThemes.loader.eager_load_namespace(MinitestShopifyThemes::Filters)
 
-class MinitestShopify::LiquidTest < Minitest::Test
+class MinitestShopifyThemes::LiquidTest < Minitest::Test
   include Capybara::Minitest::Assertions
-  include MinitestShopify::Filters::TranslationsFilter::TestHelper
-  include MinitestShopify::Filters::MoneyFilter::TestHelper
+  include MinitestShopifyThemes::Filters::TranslationsFilter::TestHelper
+  include MinitestShopifyThemes::Filters::MoneyFilter::TestHelper
 
   def render(template:, variables: {})
     @page = render_liquid(template:, variables:)
 
-    if MinitestShopify.configuration.layout_file
+    if MinitestShopifyThemes.configuration.layout_file
       @page = render_liquid(
-        template: MinitestShopify.configuration.layout_file,
+        template: MinitestShopifyThemes.configuration.layout_file,
         variables: variables.merge({ content_for_layout: @page })
       )
     end
@@ -28,7 +28,7 @@ class MinitestShopify::LiquidTest < Minitest::Test
   end
 
   def render_liquid(template:, variables:)
-    file = File.read(File.join(MinitestShopify.configuration.theme_root, template) + ".liquid")
+    file = File.read(File.join(MinitestShopifyThemes.configuration.theme_root, template) + ".liquid")
     template = Liquid::Template.parse(file, error_mode: :strict)
     @output = template.render!(deep_stringify_keys(variables), {strict_variables: true, strict_filters: true})
   end

--- a/lib/minitest_shopify_themes/local_file_system.rb
+++ b/lib/minitest_shopify_themes/local_file_system.rb
@@ -1,6 +1,6 @@
 require "liquid"
 
-module MinitestShopify
+module MinitestShopifyThemes
   # This is an override for the LocalFileSystem that is part of Liquid
   # gem.  However, out of the box it does not support snippets with a
   # '-' in the name.  This override exists to allow for that and achieve

--- a/lib/minitest_shopify_themes/tags/schema_tag.rb
+++ b/lib/minitest_shopify_themes/tags/schema_tag.rb
@@ -1,4 +1,4 @@
-class MinitestShopify::Tags::SchemaTag < Liquid::Block
+class MinitestShopifyThemes::Tags::SchemaTag < Liquid::Block
   def render(context)
     # The schema tag renders nothing.
     nil

--- a/lib/minitest_shopify_themes/tags/section_tag.rb
+++ b/lib/minitest_shopify_themes/tags/section_tag.rb
@@ -1,10 +1,10 @@
-class MinitestShopify::Tags::SectionTag < Liquid::Tag
+class MinitestShopifyThemes::Tags::SectionTag < Liquid::Tag
   def initialize(tag_name, section_name, options)
     @section_name = section_name.strip.gsub("'", "")
   end
 
   def render(context)
-    file = MinitestShopify.configuration.theme_root.join("sections", @section_name + ".liquid").read
+    file = MinitestShopifyThemes.configuration.theme_root.join("sections", @section_name + ".liquid").read
     template = Liquid::Template.parse(file, error_mode: :strict)
     template.render!
   end

--- a/lib/minitest_shopify_themes/version.rb
+++ b/lib/minitest_shopify_themes/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module MinitestShopify
+module MinitestShopifyThemes
   VERSION = "0.1.0"
 end

--- a/lib/minitest_shopify_themes/view_test.rb
+++ b/lib/minitest_shopify_themes/view_test.rb
@@ -1,4 +1,4 @@
-class MinitestShopify::ViewTest < MinitestShopify::LiquidTest
+class MinitestShopifyThemes::ViewTest < MinitestShopifyThemes::LiquidTest
   include Capybara::DSL
 
   VIEWS_DIR = Dir.mktmpdir
@@ -6,10 +6,10 @@ class MinitestShopify::ViewTest < MinitestShopify::LiquidTest
   Capybara.server = :puma, { Silent: true }
 
   def setup
-    Capybara.current_driver = MinitestShopify.configuration.selenium_driver
+    Capybara.current_driver = MinitestShopifyThemes.configuration.selenium_driver
     Capybara.app ||= Rack::Lint.new Rack::Cascade.new [
       Rack::Files.new(VIEWS_DIR),
-      Rack::URLMap.new("/assets" => Rack::Files.new(MinitestShopify.configuration.assets_dir)),
+      Rack::URLMap.new("/assets" => Rack::Files.new(MinitestShopifyThemes.configuration.assets_dir)),
     ]
   end
 

--- a/minitest_shopify_themes.gemspec
+++ b/minitest_shopify_themes.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "lib/minitest_shopify/version"
+require_relative "lib/minitest_shopify_themes/version"
 
 Gem::Specification.new do |spec|
-  spec.name = 'minitest_shopify'
-  spec.version = MinitestShopify::VERSION
+  spec.name = 'minitest_shopify_themes'
+  spec.version = MinitestShopifyThemes::VERSION
   spec.authors = ['Nick Belzer']
   spec.email = 'nickbelzer@nebulab.com'
 

--- a/test/test_assets.rb
+++ b/test/test_assets.rb
@@ -1,8 +1,8 @@
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestAssets < MinitestShopify::ViewTest
-  MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
+class TestAssets < MinitestShopifyThemes::ViewTest
+  MinitestShopifyThemes.configuration.theme_root = File.join(__dir__, "theme")
 
   def test_card
     render template: "snippets/alert"

--- a/test/test_card.rb
+++ b/test/test_card.rb
@@ -1,8 +1,8 @@
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestCard < MinitestShopify::LiquidTest
-  MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
+class TestCard < MinitestShopifyThemes::LiquidTest
+  MinitestShopifyThemes.configuration.theme_root = File.join(__dir__, "theme")
 
   def test_renders_a_card
     render template: "snippets/card", variables: { comment: default_comment }

--- a/test/test_card_view.rb
+++ b/test/test_card_view.rb
@@ -1,8 +1,8 @@
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestCardView < MinitestShopify::ViewTest
-  MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
+class TestCardView < MinitestShopifyThemes::ViewTest
+  MinitestShopifyThemes.configuration.theme_root = File.join(__dir__, "theme")
 
   def test_javascript_enabled_card
     render template: "snippets/js-card", variables: { comment: default_comment }

--- a/test/test_layout.rb
+++ b/test/test_layout.rb
@@ -1,9 +1,9 @@
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestLayout < MinitestShopify::LiquidTest
-  MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
-  MinitestShopify.configuration.layout_file = File.join("layout/theme")
+class TestLayout < MinitestShopifyThemes::LiquidTest
+  MinitestShopifyThemes.configuration.theme_root = File.join(__dir__, "theme")
+  MinitestShopifyThemes.configuration.layout_file = File.join("layout/theme")
 
   def test_renders_snippet_with_layout
     render template: "snippets/card", variables: { comment: default_comment }

--- a/test/test_section.rb
+++ b/test/test_section.rb
@@ -1,9 +1,9 @@
 require "minitest/autorun"
-require "minitest_shopify"
+require "minitest_shopify_themes"
 
-class TestSection < MinitestShopify::LiquidTest
+class TestSection < MinitestShopifyThemes::LiquidTest
   def test_renders_a_section
-    MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
+    MinitestShopifyThemes.configuration.theme_root = File.join(__dir__, "theme")
 
     section_settings = {
       settings: {
@@ -17,7 +17,7 @@ class TestSection < MinitestShopify::LiquidTest
   end
 
   def test_renders_a_section_with_image_tag
-    MinitestShopify.configuration.theme_root = File.join(__dir__, "theme")
+    MinitestShopifyThemes.configuration.theme_root = File.join(__dir__, "theme")
 
     section_settings = {
       settings: {


### PR DESCRIPTION
The old name was too broad