### PR TITLE
Add gem management bin files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new do |t|
-  t.libs << "test"
-end
-
-desc "Run tests"
+Rake::TestTask.new(:test)
 task default: :test

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "minitest_shopify_themes"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "fileutils"
+# require "optparse"
+
+def abort_with_usage
+  abort "Usage: bin/release VERSION\nExample: bin/release 1.2.3"
+end
+
+# Parse version argument
+version = ARGV[0]
+abort_with_usage unless version
+abort_with_usage unless version.match?(/^\d+\.\d+\.\d+$/)
+
+# Update version.rb
+version_file = File.expand_path("../lib/minitest_shopify_themes/version.rb", __dir__)
+content = File.read(version_file)
+new_content = content.gsub(/VERSION\s*=\s*["'].*?["']/, %Q(VERSION = "#{version}"))
+
+if content == new_content
+  abort "Version #{version} is already set in #{version_file}"
+end
+
+puts "Updating version to #{version}"
+File.write(version_file, new_content)
+
+# Commit changes
+puts "Committing changes"
+system(%Q(git commit -am "Release v#{version}")) or abort("Failed to commit changes")
+
+# Push to main branch
+puts "Pushing to main branch"
+system("git push origin main") or abort("Failed to push to main")
+
+# Release to RubyGems
+puts "Releasing to RubyGems"
+system("rake release") or abort("Failed to release gem")
+
+puts "Successfully released v#{version}!"

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+exec "bundler exec rake test"


### PR DESCRIPTION
This pull request makes updates to the `Rakefile` to streamline task definitions and improve code efficiency. The changes include adding the `frozen_string_literal` magic comment, replacing the test task configuration with a simplified version, and including `bundler/gem_tasks`.

Key changes:

* [`Rakefile`](diffhunk://#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL1-R6): Added `# frozen_string_literal: true` at the top of the file to optimize string handling.
* [`Rakefile`](diffhunk://#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL1-R6): Simplified the `Rake::TestTask` setup by removing explicit library configuration and using a named test task instead.
* [`Rakefile`](diffhunk://#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL1-R6): Added `require "bundler/gem_tasks"` to include default gem-related tasks provided by Bundler.